### PR TITLE
fix(pluginHost): allow environment variable $BROWSER

### DIFF
--- a/src/pluginHost.node/sandbox/env.ts
+++ b/src/pluginHost.node/sandbox/env.ts
@@ -12,7 +12,7 @@ const allowList = [
 	'SSH_AUTH_SOCK',
 	'TZ',
 	'DISPLAY', 'XAUTHORIZATION', 'XAUTHORITY',
-	'EDITOR', 'VISUAL',
+	'EDITOR', 'VISUAL', 'BROWSER',
 	'HOME', 'MAIL', 'PATH',
 	// Linux
 	'DBUS_SESSION_BUS_ADDRESS',


### PR DESCRIPTION
`xdg-open` script may use this environment variable

https://gitlab.freedesktop.org/xdg/xdg-utils/-/blob/master/scripts/xdg-open.in#L515